### PR TITLE
Fix "Deprecated: Creation of dynamic property" error in PHP 8.2+.

### DIFF
--- a/class-wp-package-updater.php
+++ b/class-wp-package-updater.php
@@ -74,6 +74,7 @@ if ( ! class_exists( 'WP_Package_Updater' ) ) {
 
 		private $license_server_url;
 		private $package_slug;
+		private $package_id;
 		private $update_server_url;
 		private $package_path;
 		private $package_url;


### PR DESCRIPTION
When running this plugin in PHP 8.2+ (tested within 8.2 and 8.3), this deprecated error notice is logged and causes header output errors when `display_errors` is enabled.

```
Deprecated: Creation of dynamic property WP_Package_Updater::$package_id is deprecated in .../wp-content/plugins/devogre/lib/wp-package-updater/class-wp-package-updater.php on line 106
```

The fix is simple which is just to declare `$package_id` as a property of the **WP_Package_Updater** class.